### PR TITLE
remove audio constraints request

### DIFF
--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -100,7 +100,7 @@ class CameraPlugin extends CameraPlatform {
       final html.MediaStream cameraStream =
           await _cameraService.getMediaStreamForOptions(
         const CameraOptions(
-          audio: AudioConstraints(enabled: true),
+          audio: AudioConstraints(enabled: false),
         ),
       );
 


### PR DESCRIPTION
- this gets rid of microphone permission while opening the camera
- this fixes the problem that camera didn't start on android webview